### PR TITLE
Fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
 RUN yum update -y
-RUN yum install -y cpio python3-pip yum-utils zip unzip less
+RUN yum install -y binutils cpio python3-pip yum-utils zip unzip less
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ decorator==4.3
 idna==2.8
 requests==2.21
 simplejson==3.16
-urllib3==1.24.2
+urllib3==1.26.9
 pytz==2019.3


### PR DESCRIPTION
Bump the urllib3 version since the old one is not compatible with
botocore anymore, and also has security issues.

Also install the binutils package since `clamav.py` is trying to run the
`ld` command and not finding it.