### PR TITLE
Install bzip2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
 RUN yum update -y
-RUN yum install -y binutils cpio python3-pip yum-utils zip unzip less
+RUN yum install -y binutils bzip2 cpio python3-pip yum-utils zip unzip less
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel


### PR DESCRIPTION
The scanner lambda is complaining that is can't find the `libbz2.so.1`
shared library, so install bzip2 which pulls it in.