### PR TITLE
Install ld and libbz2.so.1 within the Lambda.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 datadog==0.26.0
 decorator==4.3
 idna==2.8
-requests==2.21
+requests==2.27
 simplejson==3.16
 urllib3==1.26.9
 pytz==2019.3


### PR DESCRIPTION
The previous 2 fixes were wrong. Need to download the RPMs with the
files needed and copy them to the /opt/app/bin area so that they'll be
packaged up with the lambda.

The version of the requests module needs to be bumped to support the
newer urllib3 module.