### PR TITLE
Use new build environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,30 +1,37 @@
 steps:
-  - label: ':s3: Upload it to S3 (hetest)'
+  - label: ':package: :lambda: Lambda'
     agents:
       docker: 'true'
+      queue: build
+    artifact_paths:
+      - build/lambda.zip
     branches: master test-*
-    concurrency: 1
-    commands: 
+    commands:
       - make all
-      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-hetest
-    key: deploy_test
-    plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::530261158904:role/buildkite-$BUILDKITE_PIPELINE_SLUG
+    key: package_lambda
 
-  - label: ':s3: Upload it to S3 (heaws)'
+  - label: ':s3: Upload Lambda to S3 (hetest)'
     agents:
-      docker: 'true'
-    branches: master
-    concurrency: 1
-    commands: 
-      - make all
-      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
-    concurrency_group: $BUILDKITE_PIPELINE_SLUG/deploy-heaws
+      queue: test1
+    branches: master test-*
+    commands:
+      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
-      - deploy_test
-    key: deploy_prod
+      - package_lambda
     plugins:
-      - cultureamp/aws-assume-role#v0.1.0:
-          role: arn:aws:iam::340978087534:role/buildkite-$BUILDKITE_PIPELINE_SLUG
+      - artifacts#v1.8.0:
+          download:
+            - build/lambda.zip
+
+  - label: ':s3: Upload Lambda to S3 (heaws)'
+    agents:
+      queue: prod1
+    branches: master
+    commands:
+      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    depends_on:
+      - package_lambda
+    plugins:
+      - artifacts#v1.8.0:
+          download:
+            - build/lambda.zip


### PR DESCRIPTION
- Select the new Buildkite agents with `queue: build` on build steps to choose the agents in the shared services AWS account.

- Package the Lambda once and upload it as an artifact.

- Do the deploys of the Lambda ZIP file via the deployment agents in the same accounts the S3 bucket is located in.

- Remove unneeded concurrency entries since the ZIP is uploaded with a unique build number anyway.