### PR TITLE
PK-847 Use Python 3.11

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,19 +3,24 @@ steps:
     agents:
       docker: 'true'
       queue: build
+    branches: '!master !test-*'
+    command: make all
+
+  - label: ':package: :lambda: Lambda'
+    agents:
+      docker: 'true'
+      queue: build
     artifact_paths:
       - build/lambda.zip
     branches: master test-*
-    commands:
-      - make all
+    command: make all
     key: package_lambda
 
   - label: ':s3: Upload Lambda to S3 (hetest)'
     agents:
       queue: test1
     branches: master test-*
-    commands:
-      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:
@@ -27,8 +32,7 @@ steps:
     agents:
       queue: prod1
     branches: master
-    commands:
-      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:


### PR DESCRIPTION
Replace the use of the `amazonlinux:2` Docker image that is locked to Python 3.7 with the official Python Docker image instead.

Choose the latest version of Python that AWS Lambda currently supports.

The offical Python images are based on Debian so change RedHat/AmazonLinux commands to Debian equivalents.

Download and extract the Debian version of ClamAV.

Wehn zipping up the Python site-packages I excluded some files and directories to have the ZIP equivalent to what was produced under AmazonLinux.

Also have the pipeline confirm the Docker build works in non-master and non-test-* branches.