### PR TITLE
PK-847 python upgrade

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,19 +3,24 @@ steps:
     agents:
       docker: 'true'
       queue: build
+    branches: '!master !test-*'
+    command: make all
+
+  - label: ':package: :lambda: Lambda'
+    agents:
+      docker: 'true'
+      queue: build
     artifact_paths:
       - build/lambda.zip
     branches: master test-*
-    commands:
-      - make all
+    command: make all
     key: package_lambda
 
   - label: ':s3: Upload Lambda to S3 (hetest)'
     agents:
       queue: test1
     branches: master test-*
-    commands:
-      - aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://hetest-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:
@@ -27,8 +32,7 @@ steps:
     agents:
       queue: prod1
     branches: master
-    commands:
-      - aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
+    command: aws s3 cp build/lambda.zip s3://heaws-s3-antivirus-lambda-code/bucket-antivirus-function-$BUILDKITE_BUILD_NUMBER.zip
     depends_on:
       - package_lambda
     plugins:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM python:3.9
 
 ARG clamav_version=0.104.2
 
@@ -13,8 +13,8 @@ COPY ./*.py /opt/app/
 COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
-RUN yum update -y
-RUN yum install -y cpio python3-pip yum-utils zip unzip less wget
+RUN apt-get -qq update
+RUN apt-get -qq --no-install-recommends install zip
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
 RUN pip3 install -r requirements.txt
@@ -22,15 +22,15 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN wget https://www.clamav.net/downloads/production/clamav-${clamav_version}.linux.x86_64.rpm -O clamav.rpm -U "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0" --no-verbose
+RUN wget https://www.clamav.net/downloads/production/clamav-${clamav_version}.linux.x86_64.deb -O clamav.deb -U "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0" --no-verbose
 
-RUN rpm2cpio clamav.rpm | cpio -idmv
+RUN dpkg-deb -R clamav.deb /tmp
 
 # Copy over the binaries and libraries
 RUN cp -r /tmp/usr/local/bin/clamdscan \
        /tmp/usr/local/sbin/clamd \
        /tmp/usr/local/bin/freshclam \
-       /tmp/usr/local/lib64/* \
+       /tmp/usr/local/lib/lib* \
        /opt/app/bin/
 
 RUN echo "DatabaseDirectory /tmp/clamav_defs" > /opt/app/bin/scan.conf
@@ -47,9 +47,18 @@ RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
 WORKDIR /opt/app
 RUN zip -r9 --exclude="*test*" /opt/app/build/lambda.zip *.py bin
 
-WORKDIR /usr/local/lib/python3.7/site-packages
-RUN zip -r9 /opt/app/build/lambda.zip *
-WORKDIR /usr/local/lib64/python3.7/site-packages
-RUN zip -r9 /opt/app/build/lambda.zip *
+WORKDIR /usr/local/lib/python3.9/site-packages
+RUN zip -r9 /opt/app/build/lambda.zip * \
+      --exclude \
+        '_distutils_hack/*' \
+        distutils-precedence.pth \
+        'pip/*' \
+        'pip-*.dist-info/*' \
+        'pkg_resources/*' \
+        README.txt \
+        'setuptools/*' \
+        'setuptools-*.dist-info/*' \
+        'wheel/*' \
+        'wheel-*.dist-info/*'
 
 WORKDIR /opt/app


### PR DESCRIPTION
Use Python 3.9
    
Replace the use of the `amazonlinux:2` Docker image that is locked to Python 3.7 with the official Python Docker image instead.

The offical Python images are based on Debian so change RedHat/AmazonLinux commands to Debian equivalents.

Download and extract the Debian version of ClamAV.

When zipping up the Python site-packages I excluded some files and directories to have the ZIP equivalent to what was produced under AmazonLinux.

Also have the pipeline confirm the Docker build works in non-master and non-test-* branches.

Go to Python 3.9. Going later than that throws:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'scan': cannot import name 'Iterable' from 'collections' (/var/lang/lib/python3.11/collections/__init__.py)
```
Unfortunately no stack trace is thrown so I don't know what code dies.