### PR TITLE
PK-847 More fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG clamav_version=0.104.2
 RUN mkdir -p /opt/app
 RUN mkdir -p /opt/app/build
 RUN mkdir -p /opt/app/bin/
+RUN mkdir -p /opt/app/python_modules
 
 # Copy in the lambda source
 WORKDIR /opt/app
@@ -17,7 +18,7 @@ RUN apt-get -qq update
 RUN apt-get -qq --no-install-recommends install zip
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt --target /opt/app/python_modules
 RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
@@ -47,18 +48,7 @@ RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
 WORKDIR /opt/app
 RUN zip -r9 --exclude="*test*" /opt/app/build/lambda.zip *.py bin
 
-WORKDIR /usr/local/lib/python3.9/site-packages
-RUN zip -r9 /opt/app/build/lambda.zip * \
-      --exclude \
-        '_distutils_hack/*' \
-        distutils-precedence.pth \
-        'pip/*' \
-        'pip-*.dist-info/*' \
-        'pkg_resources/*' \
-        README.txt \
-        'setuptools/*' \
-        'setuptools-*.dist-info/*' \
-        'wheel/*' \
-        'wheel-*.dist-info/*'
+WORKDIR /opt/app/python_modules
+RUN zip -r9 /opt/app/build/lambda.zip *
 
 WORKDIR /opt/app

--- a/clamav.py
+++ b/clamav.py
@@ -17,7 +17,6 @@ import datetime
 import hashlib
 import os
 import pwd
-import re
 import subprocess
 import socket
 import errno
@@ -41,15 +40,6 @@ from common import FRESHCLAM_PATH
 from common import CLAMDSCAN_TIMEOUT
 from common import create_dir
 from common import CLAMD_SOCKET
-
-
-RE_SEARCH_DIR = r"SEARCH_DIR\(\"=([A-z0-9\/\-_]*)\"\)"
-
-
-def current_library_search_path():
-    ld_verbose = subprocess.check_output(["ld", "--verbose"]).decode("utf-8")
-    rd_ld = re.compile(RE_SEARCH_DIR)
-    return rd_ld.findall(ld_verbose)
 
 
 def update_defs_from_s3(s3_client, bucket, prefix):
@@ -116,10 +106,7 @@ def update_defs_from_freshclam(path, library_path=""):
     create_dir(path)
     fc_env = os.environ.copy()
     if library_path:
-        fc_env["LD_LIBRARY_PATH"] = "%s:%s" % (
-            ":".join(current_library_search_path()),
-            CLAMAVLIB_PATH,
-        )
+        fc_env["LD_LIBRARY_PATH"] += f":{CLAMAVLIB_PATH}"
     print("Starting freshclam with defs in %s." % path)
     fc_proc = subprocess.Popen(
         [

--- a/clamav_test.py
+++ b/clamav_test.py
@@ -48,23 +48,6 @@ class TestClamAV(unittest.TestCase):
             "sns", region_name="us-west-2"
         )
 
-    def test_current_library_search_path(self):
-        # Calling `ld --verbose` returns a lot of text but the line to check is this one:
-        search_path = """SEARCH_DIR("=/usr/x86_64-redhat-linux/lib64"); SEARCH_DIR("=/usr/lib64"); SEARCH_DIR("=/usr/local/lib64"); SEARCH_DIR("=/lib64"); SEARCH_DIR("=/usr/x86_64-redhat-linux/lib"); SEARCH_DIR("=/usr/local/lib"); SEARCH_DIR("=/lib"); SEARCH_DIR("=/usr/lib");"""  # noqa
-        rd_ld = re.compile(RE_SEARCH_DIR)
-        all_search_paths = rd_ld.findall(search_path)
-        expected_search_paths = [
-            "/usr/x86_64-redhat-linux/lib64",
-            "/usr/lib64",
-            "/usr/local/lib64",
-            "/lib64",
-            "/usr/x86_64-redhat-linux/lib",
-            "/usr/local/lib",
-            "/lib",
-            "/usr/lib",
-        ]
-        self.assertEqual(all_search_paths, expected_search_paths)
-
     def test_scan_output_to_json_clean(self):
         file_path = "/tmp/test.txt"
         signature = AV_SIGNATURE_OK

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2018.11.29
+certifi
 chardet==3.0.4
 datadog==0.26.0
 decorator==4.3


### PR DESCRIPTION
The code executed `ld --verbose` and parse it for `SEARCH_DIR("=$PATH")` statements to build up an `LD_LIBRARY_PATH` and then it would append `:$CLAMAVLIB_PATH` to the end of that when calling the freshclam binary. However the `ld` binary is not found.
It used to be available as `/usr/bin/ld` in the Python 3.7 Lamba execution environments but is no longer for Python 3.9. The runtimes already have `LD_LIBRARY_PATH` set, so remove all the code that tries to build it up and just append `:$CLAMAVLIB_PATH` to the existing value.
This is all a hack though and I've added a note to `README.md` for the correct approach that should be taken if we want to diverge more from upstream.

Remove the test in `clamav_test.py` that checks that the call to `ld` works since it is no longer relevant.

Unlock the `certifi` package since that has the CA certificate bundle which should be kept up to date.

Install the Python modules into a directory of our own making instead of having them go into the system's
`/usr/local/lib/python${VER}/site-packages` directory. That means you don't have to pass a stupidly long `--exclude` parameter to the `zip` command when packaging the Python modules into the ZIP file.

Add a `Healthengine notes` section to the `README.md` file.